### PR TITLE
Fix duplicate QR generation in Discord bot

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,11 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
+    # Ignore messages that invoke commands to avoid duplicate QR codes
+    if message.content.startswith(bot.command_prefix):
+        await bot.process_commands(message)
+        return
+
     # Check if message contains a URL
     urls = re.findall(URL_PATTERN, message.content)
     if urls:


### PR DESCRIPTION
## Summary
- avoid generating a QR code twice when the `!qr` command is used by
  ignoring URLs in command messages

## Testing
- `python -m py_compile main.py`